### PR TITLE
Mobile screens - Horizontal scroll implemented for tabs

### DIFF
--- a/src/screens/LeagueDetailPage/components/NavigationTabs.tsx
+++ b/src/screens/LeagueDetailPage/components/NavigationTabs.tsx
@@ -7,7 +7,7 @@ interface NavigationTabsProps {
 
 export function NavigationTabs({ activeView, setActiveView, sport, isAdmin = false }: NavigationTabsProps) {
   return (
-    <div className="flex border-b border-gray-200 mb-8">
+    <div className="flex flex-nowrap overflow-x-auto scrollbar-thin border-b border-gray-200 mb-8">
       <div className="flex flex-grow">
         <div 
           onClick={() => setActiveView('info')}

--- a/src/screens/MyAccount/components/AccountLayout.tsx
+++ b/src/screens/MyAccount/components/AccountLayout.tsx
@@ -31,7 +31,7 @@ export function AccountLayout() {
         </div>
 
         {/* Navigation Tabs with Icons */}
-        <div className="flex border-b border-gray-200 mb-8">
+        <div className="flex flex-nowrap overflow-x-auto scrollbar-thin border-b border-gray-200 mb-8">
           <Link
             to="/my-account/teams"
             className={`flex items-center gap-2 px-6 py-3 text-center cursor-pointer relative transition-all ${


### PR DESCRIPTION
Tabs that appear on account page, leagues page, and various other places.  

Implemented horizontal scroll for mobile screens.  

Previously it was overflowing and the whole mobile screen was horizontal scrolling.  Now the horizontal scroll is contained to the tab row only.  