### PR TITLE
Fix: Improve phone number duplicate error messaging

### DIFF
--- a/src/screens/MyAccount/components/ProfileTab/ProfileInformation.tsx
+++ b/src/screens/MyAccount/components/ProfileTab/ProfileInformation.tsx
@@ -100,6 +100,9 @@ export function ProfileInformation({
               <p className="text-xs text-gray-500 mt-1">
                 Format: ###-###-####
               </p>
+              <p className="text-xs text-gray-500 mt-1">
+                <strong>NOTE:</strong> Only one phone number per account
+              </p>
             </div>
           ) : (
             <p className="text-[#6F6F6F] py-2">{profile.phone || 'No phone number available'}</p>

--- a/src/screens/MyAccount/components/ProfileTab/useProfileOperations.ts
+++ b/src/screens/MyAccount/components/ProfileTab/useProfileOperations.ts
@@ -31,6 +31,11 @@ export function useProfileOperations(userProfile: { id: string } | null, refresh
         .eq('id', userProfile.id);
 
       if (error) {
+        // Check if it's a duplicate phone number error
+        if (error.code === '23505' && error.message.includes('phone')) {
+          showToast('The phone number you are trying to use has already been used by another user, please enter another phone number', 'error');
+          return false;
+        }
         throw error;
       }
 

--- a/src/screens/ProfileCompletionPage/ProfileCompletionPage.tsx
+++ b/src/screens/ProfileCompletionPage/ProfileCompletionPage.tsx
@@ -187,7 +187,13 @@ export function ProfileCompletionPage() {
         })
         .eq("auth_id", user?.id);
 
-      if (profileError) throw profileError;
+      if (profileError) {
+        // Check if it's a duplicate phone number error
+        if (profileError.code === '23505' && profileError.message.includes('phone')) {
+          throw new Error('The phone number you are trying to use has already been used by another user, please enter another phone number');
+        }
+        throw profileError;
+      }
 
       // Record waiver acceptance if there's an active waiver
       if (activeWaiver && waiverAccepted && user?.id) {
@@ -442,6 +448,9 @@ export function ProfileCompletionPage() {
               <p className="text-xs text-gray-500 mt-1">
                 We use your phone number for important league communications and
                 emergency contact.
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                <strong>NOTE:</strong> Only one phone number per account
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- Enhanced error messaging when a phone number is already in use
- Added clear note beneath phone input fields stating "NOTE: Only one phone number per account"
- Implemented consistent error handling across ProfileCompletionPage and ProfileTab components

## Changes
1. **ProfileCompletionPage**: Added specific error handling for duplicate phone numbers with user-friendly message
2. **ProfileTab (useProfileOperations)**: Added the same error handling to show toast notification with clear message
3. **Both components**: Added explanatory note under phone input fields

## Test Plan
- [x] Tested profile completion flow with duplicate phone number
- [x] Tested profile edit flow with duplicate phone number
- [x] Verified error messages display correctly
- [x] All existing tests pass

Fixes #191

🤖 Generated with [Claude Code](https://claude.ai/code)