### PR TITLE
Fix: Make skill level selection mandatory for individual registrations

### DIFF
--- a/src/screens/LeagueDetailPage/components/__tests__/TeamRegistrationModal.test.tsx
+++ b/src/screens/LeagueDetailPage/components/__tests__/TeamRegistrationModal.test.tsx
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { TeamRegistrationModal } from '../TeamRegistrationModal';
+import { supabase } from '../../../../lib/supabase';
+import { useAuth } from '../../../../contexts/AuthContext';
+import { useToast } from '../../../../components/ui/toast';
+
+// Mock dependencies
+vi.mock('../../../../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getSession: vi.fn(),
+    },
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../../../components/ui/toast', () => ({
+  useToast: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => vi.fn()),
+  };
+});
+
+describe('TeamRegistrationModal', () => {
+  const mockShowToast = vi.fn();
+  const mockCloseModal = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    vi.mocked(useToast).mockReturnValue({
+      showToast: mockShowToast,
+    });
+
+    vi.mocked(useAuth).mockReturnValue({
+      userProfile: {
+        id: 'user-123',
+        name: 'Test User',
+        team_ids: [],
+        league_ids: [],
+        email: 'test@example.com',
+        birthdate: '1990-01-01',
+        gender: 'Male',
+        phone: '123-456-7890',
+        pronouns: 'he/him',
+        user_sports_skills: ['volleyball', 'badminton'],
+        profile_completed: true,
+      },
+      user: {
+        email: 'test@example.com',
+      },
+    } as any);
+
+    // Mock skills loading
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'skills') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          order: vi.fn().mockResolvedValue({
+            data: [
+              { id: 1, name: 'Beginner', description: 'New to the sport', order_index: 1 },
+              { id: 2, name: 'Intermediate', description: 'Regular player', order_index: 2 },
+              { id: 3, name: 'Advanced', description: 'Experienced player', order_index: 3 },
+            ],
+            error: null,
+          }),
+        } as any;
+      }
+      return {} as any;
+    });
+  });
+
+  describe('Duplicate Registration Error Handling', () => {
+    it('should show user-friendly error for duplicate individual registration', async () => {
+      const league = {
+        id: 1,
+        name: 'Test League',
+        cost: 100,
+        team_registration: false, // Individual registration
+      };
+
+      // Mock league data fetch
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'skills') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                { id: 2, name: 'Intermediate', description: 'Regular player', order_index: 2 },
+              ],
+              error: null,
+            }),
+          } as any;
+        }
+        if (table === 'leagues') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { cost: 100, team_registration: false },
+              error: null,
+            }),
+          } as any;
+        }
+        if (table === 'users') {
+          return {
+            update: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          } as any;
+        }
+        if (table === 'league_payments') {
+          return {
+            insert: vi.fn().mockResolvedValue({
+              error: {
+                code: '23505',
+                message: 'duplicate key value violates unique constraint "idx_unique_user_league_payment"',
+              },
+            }),
+          } as any;
+        }
+        return {} as any;
+      });
+
+      render(
+        <BrowserRouter>
+          <TeamRegistrationModal
+            showModal={true}
+            closeModal={mockCloseModal}
+            leagueId={1}
+            leagueName="Test League"
+            league={league}
+          />
+        </BrowserRouter>
+      );
+
+      // Wait for skills to load
+      await waitFor(() => {
+        expect(screen.getByText(/Intermediate/)).toBeInTheDocument();
+      });
+
+      // Select skill level
+      const skillSelect = screen.getByRole('combobox');
+      fireEvent.change(skillSelect, { target: { value: '2' } });
+
+      // Submit form
+      const registerButton = screen.getByRole('button', { name: 'Register' });
+      fireEvent.click(registerButton);
+
+      // Wait for error message
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          'You have already registered for this league. Please check your registrations in the My Account page.',
+          'error'
+        );
+      });
+    });
+
+    it('should show user-friendly error for duplicate team registration', async () => {
+      const league = {
+        id: 1,
+        name: 'Test League',
+        cost: 100,
+        team_registration: true, // Team registration
+      };
+
+      // Mock league data fetch
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'skills') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                { id: 2, name: 'Intermediate', description: 'Regular player', order_index: 2 },
+              ],
+              error: null,
+            }),
+          } as any;
+        }
+        if (table === 'leagues') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { cost: 100, team_registration: true },
+              error: null,
+            }),
+          } as any;
+        }
+        if (table === 'teams') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+            insert: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              error: {
+                code: '23505',
+                message: 'duplicate key value violates unique constraint',
+              },
+            }),
+          } as any;
+        }
+        return {} as any;
+      });
+
+      render(
+        <BrowserRouter>
+          <TeamRegistrationModal
+            showModal={true}
+            closeModal={mockCloseModal}
+            leagueId={1}
+            leagueName="Test League"
+            league={league}
+          />
+        </BrowserRouter>
+      );
+
+      // Wait for skills to load
+      await waitFor(() => {
+        expect(screen.getByText(/Intermediate/)).toBeInTheDocument();
+      });
+
+      // Enter team name
+      const teamNameInput = screen.getByPlaceholderText('Enter your team name');
+      fireEvent.change(teamNameInput, { target: { value: 'Test Team' } });
+
+      // Select skill level
+      const skillSelect = screen.getByRole('combobox');
+      fireEvent.change(skillSelect, { target: { value: '2' } });
+
+      // Submit form
+      const registerButton = screen.getByRole('button', { name: 'Register' });
+      fireEvent.click(registerButton);
+
+      // Wait for error message
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          'You have already registered a team for this league. Please check your teams in the My Account page.',
+          'error'
+        );
+      });
+    });
+
+    it('should handle generic database errors gracefully', async () => {
+      const league = {
+        id: 1,
+        name: 'Test League',
+        cost: 100,
+        team_registration: false,
+      };
+
+      // Mock league data fetch with generic error
+      vi.mocked(supabase.from).mockImplementation((table: string) => {
+        if (table === 'skills') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({
+              data: [
+                { id: 2, name: 'Intermediate', description: 'Regular player', order_index: 2 },
+              ],
+              error: null,
+            }),
+          } as any;
+        }
+        if (table === 'leagues') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { cost: 100, team_registration: false },
+              error: null,
+            }),
+          } as any;
+        }
+        if (table === 'users') {
+          return {
+            update: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          } as any;
+        }
+        if (table === 'league_payments') {
+          return {
+            insert: vi.fn().mockResolvedValue({
+              error: {
+                message: 'Database connection error',
+              },
+            }),
+          } as any;
+        }
+        return {} as any;
+      });
+
+      render(
+        <BrowserRouter>
+          <TeamRegistrationModal
+            showModal={true}
+            closeModal={mockCloseModal}
+            leagueId={1}
+            leagueName="Test League"
+            league={league}
+          />
+        </BrowserRouter>
+      );
+
+      // Wait for skills to load
+      await waitFor(() => {
+        expect(screen.getByText(/Intermediate/)).toBeInTheDocument();
+      });
+
+      // Select skill level
+      const skillSelect = screen.getByRole('combobox');
+      fireEvent.change(skillSelect, { target: { value: '2' } });
+
+      // Submit form
+      const registerButton = screen.getByRole('button', { name: 'Register' });
+      fireEvent.click(registerButton);
+
+      // Wait for error message
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          'Database connection error',
+          'error'
+        );
+      });
+    });
+  });
+});

--- a/src/screens/MyAccount/components/TeamsTab/MissingSkillLevelPrompt.tsx
+++ b/src/screens/MyAccount/components/TeamsTab/MissingSkillLevelPrompt.tsx
@@ -44,15 +44,7 @@ export function MissingSkillLevelPrompt({
   const currentRegistration = missingSkillRegistrations[currentIndex];
   const isLastRegistration = currentIndex === missingSkillRegistrations.length - 1;
 
-  const handleSkip = () => {
-    if (isLastRegistration) {
-      setIsOpen(false);
-      onComplete();
-    } else {
-      setCurrentIndex(currentIndex + 1);
-      setSelectedSkillId(null);
-    }
-  };
+  // Removed handleSkip - users must set their skill level
 
   const handleUpdate = async () => {
     if (!selectedSkillId) {
@@ -104,7 +96,7 @@ export function MissingSkillLevelPrompt({
       <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
         <div
           className="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"
-          onClick={() => {}}
+          aria-hidden="true"
         />
 
         <span className="hidden sm:inline-block sm:align-middle sm:h-screen">
@@ -118,15 +110,15 @@ export function MissingSkillLevelPrompt({
             </div>
             <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
               <h3 className="text-lg leading-6 font-medium text-gray-900">
-                Set Your Skill Level
+                Skill Level Required
               </h3>
               <div className="mt-2">
                 <p className="text-sm text-gray-500">
-                  Please set your skill level for:{" "}
+                  You must set your skill level for:{" "}
                   <strong>{currentRegistration.leagueName}</strong>
                 </p>
                 <p className="text-xs text-gray-400 mt-1">
-                  {currentIndex + 1} of {missingSkillRegistrations.length} registrations need skill levels
+                  {currentIndex + 1} of {missingSkillRegistrations.length} registration{missingSkillRegistrations.length > 1 ? 's' : ''} need{missingSkillRegistrations.length === 1 ? 's' : ''} skill level
                 </p>
               </div>
 
@@ -170,14 +162,6 @@ export function MissingSkillLevelPrompt({
               className="w-full sm:w-auto"
             >
               {isUpdating ? "Updating..." : "Set Skill Level"}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={handleSkip}
-              disabled={isUpdating}
-              className="w-full sm:w-auto mt-2 sm:mt-0"
-            >
-              Skip for Now
             </Button>
           </div>
         </div>

--- a/src/screens/MyAccount/components/TeamsTab/__tests__/SkillLevelEditing.integration.test.tsx
+++ b/src/screens/MyAccount/components/TeamsTab/__tests__/SkillLevelEditing.integration.test.tsx
@@ -99,10 +99,7 @@ describe('Skill Level Editing', () => {
       });
     });
 
-    it('should show error when no skill level is selected', async () => {
-      const mockShowToast = vi.fn();
-      vi.mocked(useToast).mockReturnValue({ showToast: mockShowToast });
-
+    it('should disable update button when no skill level is selected', async () => {
       const { container } = render(
         <SkillLevelEditModal
           isOpen={true}
@@ -115,12 +112,16 @@ describe('Skill Level Editing', () => {
         />
       );
 
-      // Click update without selecting a skill level
+      // Check that update button is disabled when no skill level is selected
       const updateButton = screen.getByText('Update Skill Level');
-      fireEvent.click(updateButton);
-
-      // The component calls showToast directly, which we've mocked
-      expect(mockShowToast).toHaveBeenCalledWith('Please select a skill level', 'error');
+      expect(updateButton).toBeDisabled();
+      
+      // Select a skill level
+      const beginnerOption = screen.getByText('Beginner');
+      fireEvent.click(beginnerOption);
+      
+      // Now the button should be enabled
+      expect(updateButton).not.toBeDisabled();
     });
 
     it('should be disabled when selected skill is same as current', () => {
@@ -169,7 +170,7 @@ describe('Skill Level Editing', () => {
 
       // Check first registration is shown
       expect(screen.getByText(/League 1/)).toBeInTheDocument();
-      expect(screen.getByText('1 of 2 registrations need skill levels')).toBeInTheDocument();
+      expect(screen.getByText(/1 of 2 registration/)).toBeInTheDocument();
 
       // Select a skill level and update
       const beginnerOption = screen.getByText('Beginner');
@@ -181,11 +182,11 @@ describe('Skill Level Editing', () => {
       // Wait for second registration to appear
       await waitFor(() => {
         expect(screen.getByText(/League 2/)).toBeInTheDocument();
-        expect(screen.getByText('2 of 2 registrations need skill levels')).toBeInTheDocument();
+        expect(screen.getByText(/2 of 2 registration/)).toBeInTheDocument();
       });
     });
 
-    it('should allow skipping skill level setting', async () => {
+    it('should require skill level selection (no skip option)', async () => {
       const mockOnComplete = vi.fn();
       const missingRegistrations = [
         { paymentId: 1, leagueName: 'League 1', isTeam: false },
@@ -198,13 +199,19 @@ describe('Skill Level Editing', () => {
         />
       );
 
-      // Click skip button
-      const skipButton = screen.getByText('Skip for Now');
-      fireEvent.click(skipButton);
-
-      await waitFor(() => {
-        expect(mockOnComplete).toHaveBeenCalled();
-      });
+      // Verify skip button doesn't exist
+      expect(screen.queryByText('Skip for Now')).not.toBeInTheDocument();
+      
+      // Verify user must select a skill level
+      const setButton = screen.getByText('Set Skill Level');
+      expect(setButton).toBeDisabled(); // Disabled until a skill is selected
+      
+      // Select a skill level
+      const beginnerOption = screen.getByText('Beginner');
+      fireEvent.click(beginnerOption);
+      
+      // Now the button should be enabled
+      expect(setButton).not.toBeDisabled();
     });
 
     it('should handle team registration skill level updates', async () => {


### PR DESCRIPTION
## Summary
This PR addresses two related issues with skill level selection and registration error handling:

1. **Made skill level selection mandatory** - Removed the "Skip for now" button that allowed users to bypass skill level selection
2. **Improved duplicate registration error messages** - Added user-friendly messages when users try to register for the same league twice

## Changes

### Skill Level Selection (Commit b0152c0)
- Removed the "Skip for now" button from `MissingSkillLevelPrompt.tsx`
- Made the modal non-dismissible to ensure users complete skill level selection
- Updated modal title from "Set Your Skill Level" to "Skill Level Required"
- Fixed all related tests to reflect the new mandatory behavior

### Duplicate Registration Errors (Commit 47c4aa0)
- Added detection for PostgreSQL duplicate key constraint errors (code 23505)
- Shows user-friendly message: "You have already registered for this league. Please check your registrations in the My Account page."
- Works for both individual and team registrations
- Added comprehensive test coverage for error scenarios

## Problem Solved
Previously:
- Users could skip skill level selection, causing issues with team balancing
- Duplicate registration attempts showed cryptic database errors

Now:
- Skill level selection is mandatory for all badminton/individual registrations
- Clear, helpful error messages guide users when they've already registered

## Test Plan
- [x] All existing tests pass
- [x] New tests added for duplicate registration error handling
- [x] Verified skip button no longer exists in skill level prompt
- [x] Confirmed proper error messages display for duplicate registrations

🤖 Generated with [Claude Code](https://claude.ai/code)