### PR TITLE
Fix: Send notification emails for individual registrations

### DIFF
--- a/src/screens/LeagueDetailPage/components/__tests__/IndividualRegistrationNotification.integration.test.tsx
+++ b/src/screens/LeagueDetailPage/components/__tests__/IndividualRegistrationNotification.integration.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { TeamRegistrationModal } from '../TeamRegistrationModal';
+import { supabase } from '../../../../lib/supabase';
+import { useAuth } from '../../../../contexts/AuthContext';
+import { useToast } from '../../../../components/ui/toast';
+
+// Mock dependencies
+vi.mock('../../../../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getSession: vi.fn(),
+    },
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../../../components/ui/toast', () => ({
+  useToast: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: vi.fn(() => vi.fn()),
+  };
+});
+
+describe('Individual Registration Notification', () => {
+  const mockShowToast = vi.fn();
+  const mockCloseModal = vi.fn();
+  const mockInvoke = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    vi.mocked(useToast).mockReturnValue({
+      showToast: mockShowToast,
+    });
+
+    vi.mocked(useAuth).mockReturnValue({
+      userProfile: {
+        id: 'user-123',
+        name: 'Test User',
+        team_ids: [],
+        league_ids: [],
+        email: 'test@example.com',
+        birthdate: '1990-01-01',
+        gender: 'Male',
+        phone: '123-456-7890',
+        pronouns: 'he/him',
+        user_sports_skills: ['volleyball', 'badminton'],
+        profile_completed: true,
+      },
+      user: {
+        email: 'test@example.com',
+      },
+    } as any);
+
+    // Mock supabase functions.invoke
+    vi.mocked(supabase.functions.invoke).mockImplementation(mockInvoke);
+
+    // Mock getSession
+    vi.mocked(supabase.auth.getSession).mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'test-token',
+          user: { id: 'user-123' },
+        },
+      },
+      error: null,
+    } as any);
+
+    // Mock skills loading
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'skills') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          order: vi.fn().mockResolvedValue({
+            data: [
+              { id: 2, name: 'Intermediate', description: 'Regular player', order_index: 2 },
+              { id: 3, name: 'Advanced', description: 'Experienced player', order_index: 3 },
+            ],
+            error: null,
+          }),
+        } as any;
+      }
+      if (table === 'leagues') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: { cost: 100, team_registration: false }, // Individual registration
+            error: null,
+          }),
+        } as any;
+      }
+      if (table === 'users') {
+        return {
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        } as any;
+      }
+      if (table === 'league_payments') {
+        return {
+          insert: vi.fn().mockResolvedValue({ error: null }),
+        } as any;
+      }
+      return {} as any;
+    });
+  });
+
+  it('should send notification to info@ofsl.ca when individual registration succeeds', async () => {
+    const league = {
+      id: 1,
+      name: 'Badminton League',
+      cost: 100,
+      team_registration: false, // Individual registration
+    };
+
+    // Mock successful responses for all functions
+    mockInvoke.mockResolvedValue({ error: null });
+
+    render(
+      <BrowserRouter>
+        <TeamRegistrationModal
+          showModal={true}
+          closeModal={mockCloseModal}
+          leagueId={1}
+          leagueName="Badminton League"
+          league={league}
+        />
+      </BrowserRouter>
+    );
+
+    // Wait for skills to load
+    await waitFor(() => {
+      expect(screen.getByText(/Intermediate/)).toBeInTheDocument();
+    });
+
+    // Select skill level
+    const skillSelect = screen.getByRole('combobox');
+    fireEvent.change(skillSelect, { target: { value: '2' } });
+
+    // Submit form
+    const registerButton = screen.getByRole('button', { name: 'Register' });
+    fireEvent.click(registerButton);
+
+    // Wait for registration to complete
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'send-registration-confirmation',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            isIndividualRegistration: true,
+          }),
+        })
+      );
+    });
+
+    // Verify that notify-individual-registration was called
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'notify-individual-registration',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            userId: 'user-123',
+            userName: 'Test User',
+            userEmail: 'test@example.com',
+            userPhone: '123-456-7890',
+            leagueName: 'Badminton League',
+            amountPaid: 0,
+            paymentMethod: 'Pending',
+          }),
+        })
+      );
+    });
+
+    // Verify both functions were called
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not block registration if notification fails', async () => {
+    const league = {
+      id: 1,
+      name: 'Badminton League',
+      cost: 100,
+      team_registration: false,
+    };
+
+    // Mock notification failure but registration confirmation success
+    mockInvoke.mockImplementation((functionName) => {
+      if (functionName === 'notify-individual-registration') {
+        return Promise.resolve({ error: new Error('Notification failed') });
+      }
+      return Promise.resolve({ error: null });
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <BrowserRouter>
+        <TeamRegistrationModal
+          showModal={true}
+          closeModal={mockCloseModal}
+          leagueId={1}
+          leagueName="Badminton League"
+          league={league}
+        />
+      </BrowserRouter>
+    );
+
+    // Wait for skills to load
+    await waitFor(() => {
+      expect(screen.getByText(/Intermediate/)).toBeInTheDocument();
+    });
+
+    // Select skill level
+    const skillSelect = screen.getByRole('combobox');
+    fireEvent.change(skillSelect, { target: { value: '2' } });
+
+    // Submit form
+    const registerButton = screen.getByRole('button', { name: 'Register' });
+    fireEvent.click(registerButton);
+
+    // Wait for registration to complete successfully
+    await waitFor(() => {
+      expect(mockCloseModal).toHaveBeenCalled();
+    });
+
+    // Verify error was logged but registration succeeded
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to send individual registration notification:',
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes the missing notification emails to info@ofsl.ca when users register for individual/badminton leagues.

## Problem
When users registered for individual sports (like badminton), they would receive a confirmation email, but the admin team at info@ofsl.ca was not being notified of the new registration. This was working correctly for team registrations but not for individual registrations.

## Solution
Added a call to the `notify-individual-registration` edge function immediately after a successful individual registration. This mirrors the notification behavior that already exists for team registrations.

## Changes
- Added notification call in `TeamRegistrationModal.tsx` after individual registration succeeds
- Notification includes user details, league name, and registration timestamp
- Notification failures are logged but don't block the registration process
- Added integration tests to verify the notification is sent correctly

## Test Plan
- [x] Integration tests pass for notification sending
- [x] Tests verify that notification failures don't block registration
- [x] Verified that both user confirmation and admin notification are sent

## Impact
The admin team will now receive email notifications at info@ofsl.ca whenever someone registers for an individual league, allowing them to track and manage these registrations properly.

🤖 Generated with [Claude Code](https://claude.ai/code)