### PR TITLE
fix: payment handling and edit navigation for team transfers

### DIFF
--- a/src/screens/MyAccount/components/ManageTeamsTab/ManageTeamsTab.tsx
+++ b/src/screens/MyAccount/components/ManageTeamsTab/ManageTeamsTab.tsx
@@ -319,8 +319,8 @@ export function ManageTeamsTab() {
   };
 
   const handleEditTeam = (team: Team) => {
-    // Navigate to the league teams page
-    navigate(`/leagues/${team.league_id}/teams`);
+    // Navigate to the team edit page for this specific team
+    navigate(`/my-account/teams/edit/${team.id}`);
   };
 
   const handleTransferTeam = (team: Team) => {

--- a/supabase/functions/transfer-team/index.ts
+++ b/supabase/functions/transfer-team/index.ts
@@ -215,7 +215,25 @@ serve(async (req: Request) => {
       throw updateError
     }
 
-    // 3. Archive any league-specific standings
+    // 3. Update any existing payment records to the new league
+    // This ensures payment records stay connected to the team in its new league
+    const { error: paymentUpdateError } = await supabase
+      .from('league_payments')
+      .update({ 
+        league_id: targetLeagueId,
+        updated_at: new Date().toISOString()
+      })
+      .eq('team_id', teamId)
+      .eq('league_id', currentLeagueId)
+
+    if (paymentUpdateError) {
+      console.error("Error updating payment records:", paymentUpdateError)
+      // Non-critical - log but continue
+    } else {
+      console.log(`Updated payment records for team ${teamId} to new league ${targetLeagueId}`)
+    }
+
+    // 4. Archive any league-specific standings
     const { error: standingsError } = await supabase
       .from('league_standings')
       .delete()


### PR DESCRIPTION
## Summary
Fixes critical issues discovered after implementing team league transfer functionality.

## Fixes

### 1. Payment Records After Transfer
**Problem**: Admins couldn't add payments to transferred teams because payment records were still linked to the old league.

**Solution**: 
- Updated Edge Function to migrate `league_payments` records when transferring teams
- Payment records now follow teams to their new league
- Ensures payment continuity after transfers

### 2. Edit Button Navigation
**Problem**: Edit button on Manage Teams page navigated to league teams list instead of team-specific edit page.

**Solution**:
- Changed navigation from `/leagues/:league_id/teams` to `/my-account/teams/edit/:id`
- Provides direct access to edit specific team registrations

## Changes
- ✅ Edge Function v6 deployed - handles payment record migration
- ✅ Fixed Edit button to navigate to team-specific edit page
- ✅ Maintains payment management capabilities after team transfers

## Testing
- Tested team transfers - payment records correctly migrate
- Tested Edit button - navigates to correct team edit page
- Admin can successfully manage payments for transferred teams

## Deployment Status
- Edge Function: Already deployed to production ✅
- UI changes: Ready to merge and deploy

🤖 Generated with [Claude Code](https://claude.ai/code)