### PR TITLE
fix(standings): elite week headers + schedule week count + mobile scroll

### DIFF
--- a/src/screens/LeagueDetailPage/components/LeagueStandings.tsx
+++ b/src/screens/LeagueDetailPage/components/LeagueStandings.tsx
@@ -1,5 +1,7 @@
 import { Card, CardContent } from "../../../components/ui/card";
 import { useLeagueStandings } from "../hooks/useLeagueStandings";
+import { useEffect, useMemo, useState } from "react";
+import { supabase } from "../../../lib/supabase";
 
 interface LeagueStandingsProps {
   leagueId: string | undefined;
@@ -8,6 +10,45 @@ interface LeagueStandingsProps {
 export function LeagueStandings({ leagueId }: LeagueStandingsProps) {
   const { teams, loading, error, hasSchedule } = useLeagueStandings(leagueId);
   const formatDiff = (n: number) => (n > 0 ? `+${n}` : `${n}`);
+  const [scheduleFormat, setScheduleFormat] = useState<string | null>(null);
+  const [regularSeasonWeeks, setRegularSeasonWeeks] = useState<number>(0);
+
+  const isEliteFormat = useMemo(() => (scheduleFormat ?? "").includes("elite"), [scheduleFormat]);
+  const weeklyColumns = useMemo(() => Array.from({ length: Math.max(regularSeasonWeeks, 0) }, (_, i) => i + 1), [regularSeasonWeeks]);
+
+  useEffect(() => {
+    const loadFormatAndWeeks = async () => {
+      if (!leagueId) return;
+      try {
+        const lid = parseInt(leagueId);
+        const { data: scheduleRecord, error: scheduleError } = await supabase
+          .from('league_schedules')
+          .select('format')
+          .eq('league_id', lid)
+          .maybeSingle();
+        if (!scheduleError) {
+          setScheduleFormat(scheduleRecord?.format ?? null);
+        }
+
+        const { data: weekRows, error: weeksErr } = await supabase
+          .from('weekly_schedules')
+          .select('week_number')
+          .eq('league_id', lid);
+
+        if (!weeksErr && Array.isArray(weekRows) && weekRows.length > 0) {
+          const maxWeek = weekRows.reduce((max, r: any) => Math.max(max, r.week_number || 0), 0);
+          setRegularSeasonWeeks(maxWeek);
+        } else {
+          // Fallback to a reasonable default if no schedule rows yet
+          setRegularSeasonWeeks(12);
+        }
+      } catch (_) {
+        setRegularSeasonWeeks(12);
+      }
+    };
+
+    loadFormatAndWeeks();
+  }, [leagueId]);
   if (loading) {
     return (
       <div>
@@ -80,76 +121,81 @@ export function LeagueStandings({ leagueId }: LeagueStandingsProps) {
       {/* Standings table */}
       <Card className="shadow-md overflow-hidden rounded-lg">
         <CardContent className="p-0 overflow-hidden">
-          <div className="overflow-hidden">
-            <table className="w-full table-fixed">
-              <colgroup>
-                <col style={{ width: "10%" }} />
-                <col style={{ width: "40%" }} />
-                <col style={{ width: "12%" }} />
-                <col style={{ width: "12%" }} />
-                <col style={{ width: "13%" }} />
-                <col style={{ width: "13%" }} />
-              </colgroup>
-              <thead className="bg-gray-50 border-b">
-                <tr>
-                  <th className="px-4 py-3 text-left text-sm font-medium text-[#6F6F6F] rounded-tl-lg">
-                    #
-                  </th>
-                  <th className="px-4 py-3 text-left text-sm font-medium text-[#6F6F6F]">
-                    Team
-                  </th>
-                  <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F]">
-                    Wins
-                  </th>
-                  <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F]">
-                    Losses
-                  </th>
-                  <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F] bg-red-50">
-                    Points
-                  </th>
-                  <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F] rounded-tr-lg">
-                    +/-
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200">
-                {teams.map((team, index) => (
-                  <tr
-                    key={team.id}
-                    className={`${index % 2 === 0 ? "bg-white" : "bg-gray-50"} ${
-                      index === teams.length - 1 ? "last-row" : ""
-                    }`}
-                  >
-                    <td
-                      className={`px-4 py-3 text-sm font-medium text-[#6F6F6F] ${
-                        index === teams.length - 1 ? "rounded-bl-lg" : ""
-                      }`}
-                    >
-                      {index + 1}
-                    </td>
-                    <td className="px-4 py-3 text-sm font-semibold text-[#6F6F6F]">
-                      {team.name}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-[#6F6F6F] text-center">
-                      {team.wins}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-[#6F6F6F] text-center">
-                      {team.losses}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-[#6F6F6F] text-center bg-red-50">
-                      {team.points}
-                    </td>
-                    <td
-                      className={`px-4 py-3 text-sm text-[#6F6F6F] text-center ${
-                        index === teams.length - 1 ? "rounded-br-lg" : ""
-                      }`}
-                    >
-                      {formatDiff(team.differential as number)}
-                    </td>
+          <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: 'touch' }}>
+            {isEliteFormat ? (
+              <table className="w-full min-w-max table-auto">
+                <thead className="bg-gray-50 border-b">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-[#6F6F6F] rounded-tl-lg" rowSpan={2}>
+                      Ranking
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-[#6F6F6F]" rowSpan={2}>
+                      Team
+                    </th>
+                    <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F]" colSpan={weeklyColumns.length}>
+                      Week
+                    </th>
+                    <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F] rounded-tr-lg" rowSpan={2}>
+                      +/-
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                  <tr>
+                    {weeklyColumns.map(week => (
+                      <th key={`week-${week}`} className="px-2 py-2 text-center text-sm font-medium text-[#6F6F6F]">
+                        {week}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {teams.map((team, index) => (
+                    <tr key={team.id} className={`${index % 2 === 0 ? "bg-white" : "bg-gray-50"} ${index === teams.length - 1 ? "last-row" : ""}`}>
+                      <td className={`px-4 py-3 text-sm font-medium text-[#6F6F6F] ${index === teams.length - 1 ? "rounded-bl-lg" : ""}`}>{index + 1}</td>
+                      <td className="px-4 py-3 text-sm font-semibold text-[#6F6F6F]">{team.name}</td>
+                      {weeklyColumns.map(week => (
+                        <td key={`week-${team.id}-${week}`} className="px-4 py-3 text-center text-sm text-[#6F6F6F]">-</td>
+                      ))}
+                      <td className={`px-4 py-3 text-center ${index === teams.length - 1 ? "rounded-br-lg" : ""}`}>
+                        <span className="text-sm font-medium text-[#6F6F6F]">{formatDiff(team.differential as number)}</span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <table className="w-full min-w-max table-fixed">
+                <colgroup>
+                  <col style={{ width: "10%" }} />
+                  <col style={{ width: "40%" }} />
+                  <col style={{ width: "12%" }} />
+                  <col style={{ width: "12%" }} />
+                  <col style={{ width: "13%" }} />
+                  <col style={{ width: "13%" }} />
+                </colgroup>
+                <thead className="bg-gray-50 border-b">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-[#6F6F6F] rounded-tl-lg">#</th>
+                    <th className="px-4 py-3 text-left text-sm font-medium text-[#6F6F6F]">Team</th>
+                    <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F]">Wins</th>
+                    <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F]">Losses</th>
+                    <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F] bg-red-50">Points</th>
+                    <th className="px-4 py-3 text-center text-sm font-medium text-[#6F6F6F] rounded-tr-lg">+/-</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {teams.map((team, index) => (
+                    <tr key={team.id} className={`${index % 2 === 0 ? "bg-white" : "bg-gray-50"} ${index === teams.length - 1 ? "last-row" : ""}`}>
+                      <td className={`px-4 py-3 text-sm font-medium text-[#6F6F6F] ${index === teams.length - 1 ? "rounded-bl-lg" : ""}`}>{index + 1}</td>
+                      <td className="px-4 py-3 text-sm font-semibold text-[#6F6F6F]">{team.name}</td>
+                      <td className="px-4 py-3 text-sm text-[#6F6F6F] text-center">{team.wins}</td>
+                      <td className="px-4 py-3 text-sm text-[#6F6F6F] text-center">{team.losses}</td>
+                      <td className="px-4 py-3 text-sm text-[#6F6F6F] text-center bg-red-50">{team.points}</td>
+                      <td className={`px-4 py-3 text-sm text-[#6F6F6F] text-center ${index === teams.length - 1 ? "rounded-br-lg" : ""}`}>{formatDiff(team.differential as number)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/screens/MyAccount/components/TeamsTab/types.ts
+++ b/src/screens/MyAccount/components/TeamsTab/types.ts
@@ -14,6 +14,18 @@ export interface LeaguePayment {
   skill_name?: string | null;
 }
 
+export interface TeamMatchup {
+  status: 'scheduled' | 'bye' | 'no_schedule';
+  weekNumber: number;
+  tierNumber?: number;
+  opponents: string[];
+  location?: string | null;
+  timeSlot?: string | null;
+  court?: string | null;
+  isPlayoff?: boolean;
+  format?: string | null;
+}
+
 export interface Team {
   id: number;
   name: string;
@@ -23,6 +35,10 @@ export interface Team {
     location?: string;
     cost?: number;
     start_date?: string;
+    end_date?: string;
+    day_of_week?: number | null;
+    playoff_weeks?: number | null;
+    schedule_visible?: boolean | null;
     gym_ids?: number[];
     gyms?: Array<{
       id?: number;
@@ -44,4 +60,5 @@ export interface Team {
     amount_due: number;
     amount_paid: number;
   };
+  currentMatchup?: TeamMatchup;
 }


### PR DESCRIPTION
- Use max week_number from weekly_schedules for accurate week columns (fallback to dates)
- Compact header: group 'Week' with numeric subheaders to save space
- Apply elite-style standings layout to public view
- Enable horizontal scrolling on wide tables (mobile-friendly)