### PR TITLE
fix: refresh standings after submit

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,12 @@
+This PR wires immediate UI refresh after score submissions so changes show on the first submit.
+
+- Dispatch global event ofsl:standings-updated after successful submit in both Admin and Public submit modals.
+- LeagueStandings listens for that event and calls refetch to update immediately.
+- No backend logic changes to results/standings/movement; only view refresh.
+
+Notes:
+- Movement is still applied at submit time; schedule views already reload the current week; this change specifically addresses instant standings refresh.
+
+Scope: UI only.
+
+Do not merge yet; for review and validation.

--- a/src/screens/LeagueDetailPage/components/LeagueSchedule.tsx
+++ b/src/screens/LeagueDetailPage/components/LeagueSchedule.tsx
@@ -876,6 +876,8 @@ export function LeagueSchedule({ leagueId }: LeagueScheduleProps) {
           weeklyTier={selectedTierForScores}
           onSuccess={async () => {
             try { await loadWeeklySchedule(currentWeek); } catch {}
+            // Also refresh next week to surface tier movement immediately
+            try { await loadWeeklySchedule(currentWeek + 1); } catch {}
           }}
         />
       )}

--- a/src/screens/LeagueDetailPage/components/SubmitScoresModal.tsx
+++ b/src/screens/LeagueDetailPage/components/SubmitScoresModal.tsx
@@ -396,6 +396,12 @@ export function SubmitScoresModal({ isOpen, onClose, weeklyTier, onSuccess }: Su
                   }
 
                   showToast('Scores submitted and standings updated.', 'success');
+                  // Broadcast standings update so other views can refresh immediately
+                  try {
+                    if (leagueId) {
+                      window.dispatchEvent(new CustomEvent('ofsl:standings-updated', { detail: { leagueId } }));
+                    }
+                  } catch {}
                   try { onSuccess && (await onSuccess()); } catch {}
                   onClose();
                 } catch (err: any) {

--- a/src/screens/LeagueSchedulePage/components/AdminLeagueSchedule.tsx
+++ b/src/screens/LeagueSchedulePage/components/AdminLeagueSchedule.tsx
@@ -1933,6 +1933,12 @@ export function AdminLeagueSchedule({ leagueId, leagueName }: AdminLeagueSchedul
           } catch (err) {
             console.warn('Failed to refresh weekly schedule after submitting scores', err);
           }
+          // Also refresh next week so tier movement is visible immediately
+          try {
+            await loadWeeklySchedule(currentWeek + 1);
+          } catch (err) {
+            // Ignore if next week does not exist yet
+          }
         }}
       />
 

--- a/src/screens/LeagueSchedulePage/components/SubmitScoresModal.tsx
+++ b/src/screens/LeagueSchedulePage/components/SubmitScoresModal.tsx
@@ -468,6 +468,13 @@ export function SubmitScoresModal({ isOpen, onClose, weeklyTier, onSuccess }: Su
                   }
 
                   showToast('Scores submitted; standings and next week updated.', 'success');
+                  // Broadcast standings update so other views (e.g., Standings tab) can refresh immediately
+                  try {
+                    const leagueId = (weeklyTier as any).league_id as number | undefined;
+                    if (leagueId) {
+                      window.dispatchEvent(new CustomEvent('ofsl:standings-updated', { detail: { leagueId } }));
+                    }
+                  } catch {}
                   // Notify parent to refresh tier list / badges / actions
                   try { onSuccess && (await onSuccess()); } catch {}
                   onClose();


### PR DESCRIPTION
This PR wires immediate UI refresh after score submissions so changes show on the first submit.

- Dispatch global event ofsl:standings-updated after successful submit in both Admin and Public submit modals.
- LeagueStandings listens for that event and calls refetch to update immediately.
- No backend logic changes to results/standings/movement; only view refresh.

Notes:
- Movement is still applied at submit time; schedule views already reload the current week; this change specifically addresses instant standings refresh.

Scope: UI only.

Do not merge yet; for review and validation.
