### PR TITLE
feat: elite scorecards rules and UI updates

### DIFF
--- a/src/screens/MyAccount/components/ScorecardsFormatsTab/ScorecardsFormatsTab.tsx
+++ b/src/screens/MyAccount/components/ScorecardsFormatsTab/ScorecardsFormatsTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { GAME_FORMATS } from '../../../LeagueSchedulePage/utils/formatUtils';
 import { ScorecardsHeader } from './components/ScorecardsHeader';
 import { Scorecard3Teams6Sets } from './components/Scorecard3Teams6Sets';
+import { Scorecard3TeamsElite6Sets } from './components/Scorecard3TeamsElite6Sets';
 import { Scorecard2Teams4Sets } from './components/Scorecard2Teams4Sets';
 import { Scorecard2TeamsBestOf5 } from './components/Scorecard2TeamsBestOf5';
 import { Scorecard4TeamsHeadToHead } from './components/Scorecard4TeamsHeadToHead';
@@ -97,7 +98,7 @@ export function ScorecardsFormatsTab() {
                 </>
               ) : selected.value === '3-teams-elite-6-sets' ? (
                 <>
-                  <Scorecard3Teams6Sets teamNames={{ A: 'Setting Cobras', B: 'Hawk Serves', C: 'Prime Net' }} resultsLabel="Weekly Summary" eliteSummary={true} />
+                  <Scorecard3TeamsElite6Sets teamNames={{ A: 'Setting Cobras', B: 'Hawk Serves', C: 'Prime Net' }} />
                 </>
               ) : selected.value === '3-teams-elite-9-sets' ? (
                 <>

--- a/src/screens/MyAccount/components/ScorecardsFormatsTab/components/Scorecard3Teams6Sets.tsx
+++ b/src/screens/MyAccount/components/ScorecardsFormatsTab/components/Scorecard3Teams6Sets.tsx
@@ -68,12 +68,12 @@ export function Scorecard3Teams6Sets({ teamNames, onSubmit, isTopTier = false, p
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialSets, initialSpares]);
 
-  // Clamp score inputs; in eliteSummary mode allow deuce beyond 21 (up to 40)
+  // Clamp score inputs; eliteSummary mode capped at 21 (no deuce)
   const clampScore = (value: string): string => {
     if (value === '') return '';
     const n = Math.floor(Number(value));
     if (Number.isNaN(n)) return '';
-    const max = eliteSummary ? 40 : 21;
+    const max = eliteSummary ? 21 : 21;
     return String(Math.max(0, Math.min(max, n)));
   };
 
@@ -146,13 +146,18 @@ export function Scorecard3Teams6Sets({ teamNames, onSubmit, isTopTier = false, p
             const isTie = bothEntered && n1 === n2;
             let winner: TeamKey | null = null;
             if (bothEntered && !isTie) {
-              const maxScore = Math.max(n1 as number, n2 as number);
-              const diff = Math.abs((n1 as number) - (n2 as number));
-              const threshold = 19; // 21-point sets: win-by-2 after 19
-              const isPreThreshold = maxScore <= threshold;
-              const meetsDeuce = diff >= 2;
-              if (isPreThreshold || meetsDeuce) {
+              if (eliteSummary) {
+                // Elite: no win-by-2; any non-equal scores determine winner
                 winner = (n1! > n2!) ? t1 : t2;
+              } else {
+                const maxScore = Math.max(n1 as number, n2 as number);
+                const diff = Math.abs((n1 as number) - (n2 as number));
+                const threshold = 19; // 21-point sets: win-by-2 after 19
+                const isPreThreshold = maxScore <= threshold;
+                const meetsDeuce = diff >= 2;
+                if (isPreThreshold || meetsDeuce) {
+                  winner = (n1! > n2!) ? t1 : t2;
+                }
               }
             }
             return (
@@ -165,7 +170,7 @@ export function Scorecard3Teams6Sets({ teamNames, onSubmit, isTopTier = false, p
                       type="number"
                       inputMode="numeric"
                       min={0}
-                      max={eliteSummary ? 40 : 21}
+                      max={21}
                       step={1}
                       value={row[t1] ?? ''}
                       onChange={(e) => handleScoreChange(idx, t1, e.target.value)}
@@ -188,7 +193,7 @@ export function Scorecard3Teams6Sets({ teamNames, onSubmit, isTopTier = false, p
                       type="number"
                       inputMode="numeric"
                       min={0}
-                      max={eliteSummary ? 40 : 21}
+                      max={21}
                       step={1}
                       value={row[t2] ?? ''}
                       onChange={(e) => handleScoreChange(idx, t2, e.target.value)}
@@ -271,12 +276,9 @@ export function Scorecard3Teams6Sets({ teamNames, onSubmit, isTopTier = false, p
               if (sLeft === '' || sRight === '') return false;
               const nLeft = Number(sLeft);
               const nRight = Number(sRight);
+              // Elite: no win-by-2; just require valid non-equal scores
               if (Number.isNaN(nLeft) || Number.isNaN(nRight) || nLeft === nRight) return false;
-              if (!eliteSummary) return true;
-              const maxScore = Math.max(nLeft, nRight);
-              const diff = Math.abs(nLeft - nRight);
-              const threshold = 19;
-              return (maxScore <= threshold) || (diff >= 2);
+              return true;
             });
             const sorted = [...order].sort((x, y) => {
               const a = stats[x];
@@ -382,11 +384,8 @@ export function Scorecard3Teams6Sets({ teamNames, onSubmit, isTopTier = false, p
               if (s1 === '' || s2 === '') return false;
               const n1 = Number(s1), n2 = Number(s2);
               if (Number.isNaN(n1) || Number.isNaN(n2) || n1 === n2) return false;
-              if (!eliteSummary) return true;
-              const maxScore = Math.max(n1, n2);
-              const diff = Math.abs(n1 - n2);
-              const threshold = 19;
-              return (maxScore <= threshold) || (diff >= 2);
+              // Elite: no win-by-2 requirement; just ensure non-tie numeric entries
+              return true;
             });
             return (
               <span className="text-[11px]">
@@ -414,11 +413,8 @@ export function Scorecard3Teams6Sets({ teamNames, onSubmit, isTopTier = false, p
                 if (s1 === '' || s2 === '') return false;
                 const n1 = Number(s1), n2 = Number(s2);
                 if (Number.isNaN(n1) || Number.isNaN(n2) || n1 === n2) return false;
-                if (!eliteSummary) return true;
-                const maxScore = Math.max(n1, n2);
-                const diff = Math.abs(n1 - n2);
-                const threshold = 19;
-                return (maxScore <= threshold) || (diff >= 2);
+                // Elite: no win-by-2 requirement; just ensure non-tie numeric entries
+                return true;
               });
               return anyTie || !allComplete;
             })()}

--- a/src/screens/MyAccount/components/ScorecardsFormatsTab/components/Scorecard3TeamsElite6Sets.tsx
+++ b/src/screens/MyAccount/components/ScorecardsFormatsTab/components/Scorecard3TeamsElite6Sets.tsx
@@ -1,0 +1,15 @@
+import type { ComponentProps } from 'react';
+import { Scorecard3Teams6Sets } from './Scorecard3Teams6Sets';
+
+type Props = Omit<ComponentProps<typeof Scorecard3Teams6Sets>, 'eliteSummary' | 'resultsLabel'>;
+
+// Elite-specific 3-team (6 sets) scorecard wrapper
+// Forces elite-only behavior without affecting the standard 3-team component.
+export function Scorecard3TeamsElite6Sets(props: Props) {
+  return (
+    <Scorecard3Teams6Sets
+      {...props}
+      eliteSummary={true}
+    />
+  );
+}


### PR DESCRIPTION
This PR updates only elite scorecards:

- 2 teams (Elite):
  - Remove win-by-2; no ties
  - Sets 1–4 cap 25; Set 5 cap 15
  - Submit enabled when a team reaches 3 valid sets; footer shows 'First to 3 sets wins.'

- 3 teams (Elite 6 sets):
  - Cap 21; no ties; no win-by-2
  - Summary and submit checks aligned to elite rules

- 3 teams (Elite 9 sets):
  - Per pairing best-of-3; per-set rules: sets 1–2 winner score 21 or 25, decider (set 3) winner score 15; no ties
  - Per-set W/L badges; footer help removed; submit when all pairings decided

Plumbing:
- Added wrapper component for 3-team elite 6-sets; wired modal and admin preview to use it.

No non-elite scorecards or formats were changed.