### PR TITLE
feat(schedule): Elite tier tag + migration

### DIFF
--- a/src/screens/LeagueDetailPage/components/LeagueSchedule.tsx
+++ b/src/screens/LeagueDetailPage/components/LeagueSchedule.tsx
@@ -484,6 +484,11 @@ export function LeagueSchedule({ leagueId }: LeagueScheduleProps) {
                       <div>
                         <h3 className="font-bold text-gray-400 text-xl leading-none m-0">
                           Tier {templateLabelMap.get((tier.id ?? tier.tier_number) as number) || getTierDisplayLabel(tier.format, tier.tier_number)}
+                          {tier.is_elite && (
+                            <span className="ml-2 inline-flex items-center align-middle px-2 py-0.5 text-xs font-semibold bg-[#B20000] text-white rounded-full">
+                              Elite
+                            </span>
+                          )}
                         </h3>
                       </div>
 
@@ -544,6 +549,11 @@ export function LeagueSchedule({ leagueId }: LeagueScheduleProps) {
                     <div className="flex items-center gap-3">
                       <h3 className={`flex items-center font-bold text-[#6F6F6F] text-xl leading-none m-0 ${tier.no_games ? 'opacity-50' : ''}`}>
                         Tier {labelMap.get((tier.id ?? tier.tier_number) as number) || getTierDisplayLabel(tier.format, tier.tier_number)}
+                        {tier.is_elite && (
+                          <span className="ml-2 inline-flex items-center align-middle px-2 py-0.5 text-xs font-semibold bg-[#B20000] text-white rounded-full">
+                            Elite
+                          </span>
+                        )}
                         {(tier.is_completed || submittedTierNumbers.has(tier.tier_number)) && (
                           <span className="ml-2 inline-flex items-center align-middle px-2 py-1 text-xs bg-green-100 text-green-800 rounded">
                             Completed

--- a/src/screens/LeagueSchedulePage/components/AdminLeagueSchedule.tsx
+++ b/src/screens/LeagueSchedulePage/components/AdminLeagueSchedule.tsx
@@ -1541,6 +1541,11 @@ export function AdminLeagueSchedule({ leagueId, leagueName }: AdminLeagueSchedul
                       <div>
                         <h3 className="font-bold text-gray-400 text-xl leading-none m-0">
                           Tier {getLabel(tier)}
+                          {tier.is_elite && (
+                            <span className="ml-2 px-2 py-0.5 text-xs font-semibold bg-[#B20000] text-white rounded-full">
+                              Elite
+                            </span>
+                          )}
                         </h3>
                       </div>
 
@@ -1608,6 +1613,11 @@ export function AdminLeagueSchedule({ leagueId, leagueName }: AdminLeagueSchedul
                         <div className="flex items-center gap-3">
                       <h3 className={`font-bold text-[#6F6F6F] text-xl leading-none m-0 ${tier.no_games ? 'opacity-50' : ''}`}>
                         Tier {getLabel(tier)}
+                        {tier.is_elite && (
+                          <span className="ml-2 px-2 py-0.5 text-xs font-semibold bg-[#B20000] text-white rounded-full">
+                            Elite
+                          </span>
+                        )}
                         {(tier.is_completed || submittedTierNumbers.has(tier.tier_number)) && (
                           <span className="ml-2 px-2 py-1 text-xs bg-green-100 text-green-800 rounded">
                             Completed
@@ -1692,6 +1702,41 @@ export function AdminLeagueSchedule({ leagueId, leagueName }: AdminLeagueSchedul
                                 className="rounded"
                               />
                               No games
+                            </label>
+                          )}
+
+                          {isEditScheduleMode && (
+                            <label className="ml-3 flex items-center gap-2 text-sm text-gray-700" onClick={(e) => e.stopPropagation()}>
+                              <input
+                                type="checkbox"
+                                checked={!!tier.is_elite}
+                                onClick={(e) => e.stopPropagation()}
+                                onChange={async (e) => {
+                                  const nextValue = e.target.checked;
+                                  const previousValue = Boolean(tier.is_elite);
+
+                                  // Optimistic UI update
+                                  setWeeklyTiers((prev) => prev.map((t) => t.id === tier.id ? { ...t, is_elite: nextValue } : t));
+
+                                  try {
+                                    const leagueIdNum = parseInt(leagueId);
+                                    const tierNumber = tier.tier_number;
+                                    const { error } = await supabase
+                                      .from('weekly_schedules')
+                                      .update({ is_elite: nextValue })
+                                      .eq('league_id', leagueIdNum)
+                                      .eq('tier_number', tierNumber);
+                                    if (error) throw error;
+                                  } catch (err) {
+                                    console.error('Failed to update tier is_elite', err);
+                                    alert('Failed to update Elite setting. Reverting.');
+                                    // Revert UI
+                                    setWeeklyTiers((prev) => prev.map((t) => t.id === tier.id ? { ...t, is_elite: previousValue } : t));
+                                  }
+                                }}
+                                className="rounded"
+                              />
+                              Elite
                             </label>
                           )}
                           

--- a/src/screens/LeagueSchedulePage/types/index.ts
+++ b/src/screens/LeagueSchedulePage/types/index.ts
@@ -30,6 +30,7 @@ export interface WeeklyScheduleTier {
   time_slot: string;
   court: string;
   format: string;
+  is_elite?: boolean;
   team_a_name: string | null;
   team_a_ranking: number | null;
   team_b_name: string | null;
@@ -63,6 +64,7 @@ export interface NormalizedTier {
   time_slot: string;
   court: string;
   format: string;
+  is_elite?: boolean;
   teams: {
     A: TeamPosition | null;
     B: TeamPosition | null;
@@ -202,6 +204,7 @@ export interface TierUpdatePayload {
   time_slot?: string;
   court?: string;
   format?: GameFormatId;
+  is_elite?: boolean;
   team_a_name?: string | null;
   team_a_ranking?: number | null;
   team_b_name?: string | null;

--- a/supabase/migrations/20250925000001_add_is_elite_flag_to_weekly_schedules.sql
+++ b/supabase/migrations/20250925000001_add_is_elite_flag_to_weekly_schedules.sql
@@ -1,0 +1,7 @@
+-- Add is_elite flag to weekly_schedules table
+-- Indicates whether this tier is designated as Elite level for that week
+ALTER TABLE weekly_schedules 
+ADD COLUMN IF NOT EXISTS is_elite BOOLEAN DEFAULT FALSE;
+
+COMMENT ON COLUMN weekly_schedules.is_elite IS 'When true, indicates this tier is at the Elite level for this week';
+


### PR DESCRIPTION
Adds Elite flag for tiers, admin toggle, public/admin rendering, and DB migration (is_elite column). Includes migration file under supabase/migrations. \n\n- UI: Elite pill before Completed in tier headers\n- Admin: Elite checkbox applies across all weeks for tier\n- Types: adds is_elite to WeeklyScheduleTier/TierUpdatePayload\n- DB: adds is_elite column to weekly_schedules\n\nTested on staging by running the SQL manually. Please review and merge to staging.