### PR TITLE
feat(schedule): restrict tier format changes across simple and elite groups

### DIFF
--- a/src/screens/LeagueSchedulePage/utils/scheduleLogic.ts
+++ b/src/screens/LeagueSchedulePage/utils/scheduleLogic.ts
@@ -124,12 +124,52 @@ export function validateFormatChange(
   tier: WeeklyScheduleTier,
   newFormat: GameFormatId
 ): FormatValidationResult {
+  // New restriction set: simple formats can only change among themselves
+  // Allowed trio: 3 teams (6 sets), 2 teams (4 sets), 2 teams (Best of 5)
+  const SIMPLE_GROUP: readonly GameFormatId[] = [
+    '3-teams-6-sets',
+    '2-teams-4-sets',
+    '2-teams-best-of-5',
+  ] as const;
+
+  // New restriction set: elite formats can only change among themselves
+  // Allowed trio: 2 teams (Elite), 3 teams (Elite 6 sets), 3 teams (Elite 9 sets)
+  const ELITE_GROUP: readonly GameFormatId[] = [
+    '2-teams-elite',
+    '3-teams-elite-6-sets',
+    '3-teams-elite-9-sets',
+  ] as const;
+
+  const currentFormat = String(tier.format || '').toLowerCase();
+  const normalizedNew = String(newFormat).toLowerCase();
+
+  // If current format is in the simple group, only allow switching within that group
+  if ((SIMPLE_GROUP as readonly string[]).includes(currentFormat)) {
+    const allowed = (SIMPLE_GROUP as readonly string[]).includes(normalizedNew);
+    if (!allowed) {
+      return {
+        isValid: false,
+        reason:
+          'Tiers in 3 teams (6 sets), 2 teams (4 sets), or 2 teams (Best of 5) may only change between those three. Changes to 6 teams (head-to-head), 4 teams (head-to-head), 2 teams (Elite), 3 teams (Elite 6 sets), or 3 teams (Elite 9 sets) are not allowed.'
+      };
+    }
+  }
+
+  // If current format is in the elite group, only allow switching within that group
+  if ((ELITE_GROUP as readonly string[]).includes(currentFormat)) {
+    const allowed = (ELITE_GROUP as readonly string[]).includes(normalizedNew);
+    if (!allowed) {
+      return {
+        isValid: false,
+        reason:
+          'Tiers in 2 teams (Elite), 3 teams (Elite 6 sets), or 3 teams (Elite 9 sets) may only change between those three. Changes to 3 teams (6 sets), 2 teams (4 sets), 2 teams (Best of 5), 4 teams (head-to-head), or 6 teams (head-to-head) are not allowed.'
+      };
+    }
+  }
   // Special restriction: When current format is 6-teams-head-to-head, only allow
   // changing to 4-teams-head-to-head (subject to capacity validation below).
   // Disallow switching to any elite formats or 2/3-team standard formats.
-  const currentFormat = String(tier.format || '').toLowerCase();
   if (currentFormat === '6-teams-head-to-head') {
-    const normalizedNew = String(newFormat).toLowerCase();
     const isSame = normalizedNew === currentFormat;
     const allowedTarget = '4-teams-head-to-head';
     if (!isSame && normalizedNew !== allowedTarget) {
@@ -143,7 +183,6 @@ export function validateFormatChange(
   // changing to 6-teams-head-to-head (subject to capacity validation below).
   // Disallow switching to any elite formats or 2/3-team standard formats.
   if (currentFormat === '4-teams-head-to-head') {
-    const normalizedNew = String(newFormat).toLowerCase();
     const isSame = normalizedNew === currentFormat;
     const allowedTarget = '6-teams-head-to-head';
     if (!isSame && normalizedNew !== allowedTarget) {


### PR DESCRIPTION
This PR adds format-change restrictions when editing tiers.

Key changes:
- Simple formats (3 teams (6 sets), 2 teams (4 sets), 2 teams (Best of 5)) can only switch among themselves.
- Elite formats (2 teams (Elite), 3 teams (Elite 6 sets), 3 teams (Elite 9 sets)) can only switch among themselves.
- Existing head-to-head special rules remain (4↔6 teams only).

Implementation:
- Validation enforced in Tier Edit modal via schedule validation util.
- File: src/screens/LeagueSchedulePage/utils/scheduleLogic.ts

Notes:
- Typecheck passes (npm run typecheck).
- UI disables incompatible options and shows reason text.