### PR TITLE
feat(standings): Elite Clear Data reset at week 3

### DIFF
--- a/src/standings/useEliteStandings.ts
+++ b/src/standings/useEliteStandings.ts
@@ -30,7 +30,14 @@ export function useEliteStandings(leagueId?: number | string) {
           .eq('league_id', lid)
           .eq('active', true);
 
-        const elitePresent = Array.isArray(weekRows) && (weekRows as any[]).some(r => String((r as any).format || '').toLowerCase().includes('elite'));
+        const elitePresent = Array.isArray(weekRows) && (weekRows as any[]).some(r => {
+          const fmt = String((r as any).format || '').toLowerCase();
+          return (
+            fmt.includes('2-teams-elite') ||
+            fmt.includes('3-teams-elite-6-sets') ||
+            fmt.includes('3-teams-elite-9-sets')
+          );
+        });
         setIsElite(elitePresent);
 
         const { seedRanksByTeamId, weeklyRanksByTeamId, maxWeek } = computeEliteWeeklyRanks((weekRows || []) as WeeklyScheduleRow[], (teamRows || []) as TeamRow[]);


### PR DESCRIPTION
This PR updates the standings Clear Data behavior.

Elite formats (2-teams elite, 3-teams elite 6 sets, 3-teams elite 9 sets):
- Clear Data now restarts standings at week 3
- Weeks 1–2 are greyed out in elite tables (admin + public)
- Ranking column shows '-' until week 3 results, then computes from week 3 forward
- Button disables after week 3 is completed

Regular formats (3-teams 6 sets, 2-teams 4 sets, 2-teams best of 5, 4-teams head-to-head, 6-teams head-to-head):
- Clear Data keeps legacy behavior (zero numeric stats)
- Button disables after week 3 is completed

Also tightens elite detection to only the three explicit elite formats; does not rely on tier-level is_elite markers.

Do not merge yet; for review only.