### PR TITLE
fix(announcement): smoother re-show and reliable top reappearance

### DIFF
--- a/src/components/AnnouncementBar.tsx
+++ b/src/components/AnnouncementBar.tsx
@@ -3,7 +3,11 @@ import { Link } from "react-router-dom";
 import { fetchActiveAnnouncement } from "../lib/announcement";
 import type { SiteAnnouncement } from "../lib/announcement";
 
-export function AnnouncementBar() {
+interface AnnouncementBarProps {
+  visible?: boolean;
+}
+
+export function AnnouncementBar({ visible = true }: AnnouncementBarProps) {
   const [announcement, setAnnouncement] = useState<SiteAnnouncement | null>(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -44,7 +48,11 @@ export function AnnouncementBar() {
   }
 
   return (
-    <div className="w-full bg-black py-2 md:py-2.5 relative z-50">
+    <div
+      className={`w-full bg-black relative z-50 overflow-hidden transition-all duration-300 ease-in-out
+        ${visible ? "max-h-24 opacity-100 translate-y-0 py-2 md:py-2.5" : "max-h-0 opacity-0 -translate-y-2 py-0"}`}
+      aria-hidden={!visible}
+    >
       <div className="max-w-[1280px] mx-auto px-4 flex items-center justify-center">
         <div className="font-normal text-white text-sm md:text-base text-center">
           <span className="tracking-[0.08px]">{message} </span>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,7 +17,8 @@ export function Layout() {
     const COMPACT_THRESHOLD = 80; // Increased threshold to switch to compact when scrolling down
     const EXPAND_THRESHOLD = 30; // Decreased threshold to switch to expanded when scrolling up
     const ANNOUNCEMENT_HIDE_THRESHOLD = 10;
-    const ANNOUNCEMENT_SHOW_THRESHOLD = 0;
+    // Allow announcement bar to reappear when near the top (not only at exact 0)
+    const ANNOUNCEMENT_SHOW_THRESHOLD = 30;
     const STATE_CHANGE_DELAY = 200; // Increased delay between state changes
     const MIN_SCROLL_DISTANCE = 5; // Minimum scroll distance to consider a direction change
     
@@ -58,6 +59,10 @@ export function Layout() {
             } else if (!scrollingDown && lastDirection.current === 'up' && 
                       currentScrollY < EXPAND_THRESHOLD && isCompactHeader) {
               setIsCompactHeader(false);
+              // When header expands again near the top, ensure announcement bar is visible
+              if (!showAnnouncement) {
+                setShowAnnouncement(true);
+              }
               lastStateChangeTime.current = now;
             }
           }
@@ -77,7 +82,7 @@ export function Layout() {
   return (
     <div className="bg-white w-full">
       <div className="sticky top-0 z-50">
-        {showAnnouncement && <AnnouncementBar />}
+        <AnnouncementBar visible={showAnnouncement} />
         <Header isCompact={isCompactHeader} />
       </div>
       <Outlet />


### PR DESCRIPTION
- Smoothly animate announcement bar show/hide (max-height, opacity, translate)
- Keep component mounted to avoid snap-in/out
- Re-show near top (< 30px) and when header expands

Manual QA
- Scroll down: bar hides smoothly
- Scroll near top: bar reappears without hunting for exact 0px
- Header compact/expand syncs with bar visibility