### PR TITLE
fix(schedule): keep header and schedule week in sync after score submission

### DIFF
--- a/src/screens/LeagueDetailPage/components/LeagueSchedule.tsx
+++ b/src/screens/LeagueDetailPage/components/LeagueSchedule.tsx
@@ -935,9 +935,9 @@ export function LeagueSchedule({ leagueId }: LeagueScheduleProps) {
           }}
           weeklyTier={selectedTierForScores}
           onSuccess={async () => {
+            // Refresh the currently displayed week only to keep
+            // header and schedule content in sync after submission.
             try { await loadWeeklySchedule(currentWeek); } catch {}
-            // Also refresh next week to surface tier movement immediately
-            try { await loadWeeklySchedule(currentWeek + 1); } catch {}
           }}
         />
       )}

--- a/src/screens/LeagueSchedulePage/components/AdminLeagueSchedule.tsx
+++ b/src/screens/LeagueSchedulePage/components/AdminLeagueSchedule.tsx
@@ -2257,12 +2257,11 @@ export function AdminLeagueSchedule({ leagueId, leagueName }: AdminLeagueSchedul
           } catch (err) {
             console.warn('Failed to refresh weekly schedule after submitting scores', err);
           }
-          // Also refresh next week so tier movement is visible immediately
-          try {
-            await loadWeeklySchedule(currentWeek + 1);
-          } catch (err) {
-            // Ignore if next week does not exist yet
-          }
+          // Note: Avoid loading next week here. Doing so would update
+          // the shared weekly state to Week (currentWeek + 1) while the
+          // header still shows Week currentWeek, causing a mismatch.
+          // If we want to prefetch next week later, implement a cache
+          // that does not overwrite the displayed week state.
         }}
       />
 


### PR DESCRIPTION
- Root cause: After submitting scores, the app refreshed current week then also loaded next week; the last-loaded data overwrote the displayed week, desynchronizing header and schedule.
- Fix: Refresh only the currently displayed week in onSuccess callbacks; do not load next week there.
- Impact: Keeps week header and schedule tiers aligned immediately after a submission; movement is still applied and visible when navigating to the next week.